### PR TITLE
Missing whitespace around the model, typos fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -392,7 +392,7 @@
   * Check for input `item` in S3 methods for `difNLR()`, `ddfMLR()`, and `ddfORD()`
     was fixed.
 
-#### MAJOR UDPATES
+#### MAJOR UPDATES
   * S3 methods `plot()` outputs for `difNLR()`, `ddfMLR()`, and `ddfORD()` functions 
   were unified.
 
@@ -404,7 +404,7 @@
 
 ### Changes in version 1.2.6 (2019-07-03)
 
-#### MAJOR UDPATES
+#### MAJOR UPDATES
   * S3 method `plot()` for `ddfORD()` was implemented.
 
 ------

--- a/R/GMAT.R
+++ b/R/GMAT.R
@@ -38,6 +38,6 @@
 #' \describe{
 #' \item{Item1-Item20}{dichotomously scored items of the test}
 #' \item{group}{group membership vector, \code{"0"} reference group, \code{"1"} focal group}
-#' \item{criterion}{continuous critetion intended to be predicted by test}
+#' \item{criterion}{continuous criterion intended to be predicted by test}
 #' }
 "GMAT"

--- a/R/GMAT2test.R
+++ b/R/GMAT2test.R
@@ -3,7 +3,7 @@
 #' @description The \code{GMAT2test} is a generated dataset based on parameters from Graduate Management
 #' Admission Test (GMAT, Kingston et al., 1985). First two items were considered to function differently
 #' in uniform and non-uniform way respectively. The data set represents responses of 1,000 subjects to
-#' multiple-choice test of 20 items. Aditionally, 4 possible answers on all items were generated,
+#' multiple-choice test of 20 items. Additionally, 4 possible answers on all items were generated,
 #' coded A, B, C, and D. The column \code{group} represents group membership, where 0 indicates reference group
 #' and 1 indicates focal group. Groups are the same size (i.e. 500 per group).
 #'

--- a/R/GMATtest.R
+++ b/R/GMATtest.R
@@ -4,7 +4,7 @@
 #' Graduate Management Admission Test (GMAT, Kingston et al., 1985). First two items
 #' were considered to function differently in uniform and non-uniform way respectively.
 #' The dataset represents responses of 2,000 subjects to multiple-choice test of 20 items.
-#' Aditionally, 4 possible answers on all items were generated, coded A, B, C, and D. The column
+#' Additionally, 4 possible answers on all items were generated, coded A, B, C, and D. The column
 #' \code{group} represents group membership, where 0 indicates reference group and 1 indicates
 #' focal group. Groups are the same size (i.e. 1,000 per group). The distributions of total scores
 #' (sum of correct answers) are the same for both reference and focal group (Martinkova et al., 2017).
@@ -39,7 +39,7 @@
 #' \describe{
 #' \item{Item1-Item20}{nominal items of the test coded A, B, C, and D}
 #' \item{group}{group membership vector, \code{"0"} reference group, \code{"1"} focal group}
-#' \item{criterion}{continuous critetion intended to be predicted by test}
+#' \item{criterion}{continuous criterion intended to be predicted by test}
 #' }
 #' Correct answers are presented in \code{\link{GMATkey}} data set.
 "GMATtest"

--- a/R/ORD.R
+++ b/R/ORD.R
@@ -7,7 +7,7 @@
 #'   on cumulative logit regression model.
 #'
 #' @param Data data.frame or matrix: dataset which rows represent
-#'   ordinaly scored examinee answers and columns correspond to the
+#'   ordinally scored examinee answers and columns correspond to the
 #'   items.
 #' @param group numeric: binary vector of group membership. \code{"0"}
 #'   for reference group, \code{"1"} for focal group.

--- a/R/difNLR.R
+++ b/R/difNLR.R
@@ -836,7 +836,7 @@ print.difNLR <- function(x, ...) {
       " statistics",
       ifelse(length(unique(x$model)) == 1,
         paste0(
-          "\nbased on",
+          "\nbased on ",
           switch(unique(x$model),
             "Rasch" = "Rasch model",
             "1PL" = "1PL model",

--- a/R/difORD.R
+++ b/R/difORD.R
@@ -7,7 +7,7 @@
 #'   logit model and likelihood ratio test of a submodel.
 #'
 #' @param Data data.frame or matrix: dataset which rows represent
-#'   ordinaly scored examinee answers and columns correspond to the
+#'   ordinally scored examinee answers and columns correspond to the
 #'   items. In addition, \code{Data} can hold the vector of group
 #'   membership.
 #' @param group numeric or character: a dichotomous vector of the same

--- a/R/genNLR.R
+++ b/R/genNLR.R
@@ -37,7 +37,7 @@
 #' First 3 columns correspond to distractors parameters for reference group and last three columns
 #' for focal group. The number of choices can differ for items. Matrices \code{a} and \code{b}
 #' need to consist of as many columns as is the maximum number of distractors. Items with less
-#' choices can containt NAs.
+#' choices can contain NAs.
 #'
 #' @usage genNLR(N = 1000, ratio = 1, itemtype = "dich", a, b, c, d, mu = 0, sigma = 1)
 #'

--- a/man/GMAT.Rd
+++ b/man/GMAT.Rd
@@ -9,7 +9,7 @@ A \code{GMAT} data frame consists of 2,000 observations on the following 22 vari
 \describe{
 \item{Item1-Item20}{dichotomously scored items of the test}
 \item{group}{group membership vector, \code{"0"} reference group, \code{"1"} focal group}
-\item{criterion}{continuous critetion intended to be predicted by test}
+\item{criterion}{continuous criterion intended to be predicted by test}
 }
 }
 \usage{

--- a/man/GMAT2test.Rd
+++ b/man/GMAT2test.Rd
@@ -19,7 +19,7 @@ data(GMAT2test)
 The \code{GMAT2test} is a generated dataset based on parameters from Graduate Management
 Admission Test (GMAT, Kingston et al., 1985). First two items were considered to function differently
 in uniform and non-uniform way respectively. The data set represents responses of 1,000 subjects to
-multiple-choice test of 20 items. Aditionally, 4 possible answers on all items were generated,
+multiple-choice test of 20 items. Additionally, 4 possible answers on all items were generated,
 coded A, B, C, and D. The column \code{group} represents group membership, where 0 indicates reference group
 and 1 indicates focal group. Groups are the same size (i.e. 500 per group).
 }

--- a/man/GMATtest.Rd
+++ b/man/GMATtest.Rd
@@ -9,7 +9,7 @@ A \code{GMATtest} data frame consists of 2,000 observations on the following 22 
 \describe{
 \item{Item1-Item20}{nominal items of the test coded A, B, C, and D}
 \item{group}{group membership vector, \code{"0"} reference group, \code{"1"} focal group}
-\item{criterion}{continuous critetion intended to be predicted by test}
+\item{criterion}{continuous criterion intended to be predicted by test}
 }
 Correct answers are presented in \code{\link{GMATkey}} data set.
 }
@@ -21,7 +21,7 @@ The \code{GMATtest} is a generated dataset based on parameters from
 Graduate Management Admission Test (GMAT, Kingston et al., 1985). First two items
 were considered to function differently in uniform and non-uniform way respectively.
 The dataset represents responses of 2,000 subjects to multiple-choice test of 20 items.
-Aditionally, 4 possible answers on all items were generated, coded A, B, C, and D. The column
+Additionally, 4 possible answers on all items were generated, coded A, B, C, and D. The column
 \code{group} represents group membership, where 0 indicates reference group and 1 indicates
 focal group. Groups are the same size (i.e. 1,000 per group). The distributions of total scores
 (sum of correct answers) are the same for both reference and focal group (Martinkova et al., 2017).

--- a/man/ORD.Rd
+++ b/man/ORD.Rd
@@ -10,7 +10,7 @@ ORD(Data, group, model = "adjacent", type = "both", match = "zscore",
 }
 \arguments{
 \item{Data}{data.frame or matrix: dataset which rows represent
-ordinaly scored examinee answers and columns correspond to the
+ordinally scored examinee answers and columns correspond to the
 items.}
 
 \item{group}{numeric: binary vector of group membership. \code{"0"}

--- a/man/difNLR-package.Rd
+++ b/man/difNLR-package.Rd
@@ -20,7 +20,7 @@ The difNLR package contains method for detection of differential
 Package: difNLR\cr
 Type: Package\cr
 Version: 1.5.0\cr
-Date: 2024-12-14\cr
+Date: 2024-12-15\cr
 Depends: R (>= 4.0.0)\cr
 Imports: calculus, ggplot2 (>= 3.4.0), msm, nnet, plyr, stats, VGAM\cr
 Suggests: ShinyItemAnalysis\cr

--- a/man/difORD.Rd
+++ b/man/difORD.Rd
@@ -10,7 +10,7 @@ difORD(Data, group, focal.name, model = "adjacent", type = "both", match = "zsco
 }
 \arguments{
 \item{Data}{data.frame or matrix: dataset which rows represent
-ordinaly scored examinee answers and columns correspond to the
+ordinally scored examinee answers and columns correspond to the
 items. In addition, \code{Data} can hold the vector of group
 membership.}
 

--- a/man/genNLR.Rd
+++ b/man/genNLR.Rd
@@ -58,7 +58,7 @@ item with 4 different choices is supposed to be generated, user provide matrices
 First 3 columns correspond to distractors parameters for reference group and last three columns
 for focal group. The number of choices can differ for items. Matrices \code{a} and \code{b}
 need to consist of as many columns as is the maximum number of distractors. Items with less
-choices can containt NAs.
+choices can contain NAs.
 }
 \examples{
 # seed


### PR DESCRIPTION
Git diff is messy for some reason, but the change in difNLR.R is only on the line 839 here:
<img width="489" alt="Snímek obrazovky 2024-12-17 v 13 09 21" src="https://github.com/user-attachments/assets/ce6bbf9b-64bc-4bc7-a1e2-937815f35a31" />
